### PR TITLE
Parsing the auth cookie at login is now delegated to the cookie package

### DIFF
--- a/lib/mnm.js
+++ b/lib/mnm.js
@@ -2,6 +2,7 @@
 var htmlparser2 = require("htmlparser2")
 //var formdata = require('form-data')
 const http = require('http.min')
+const cookie = require("cookie");
 //const HS = require('./haversine')
 //const { ManagerSettings } = require('homey');
 
@@ -50,18 +51,6 @@ function getSessionCookie(setcookie)
                 cookie=val
         });
     return cookie
-}
-
-function parseAuthCookie(setcookie)
-{
-    var cookie=''
-    setcookie.split('; ').map(
-        function (val) { 
-            var cookiename = val.split('=')[0]
-            if(cookiename==='tnm_api')
-                cookie=val.split('=')[1]
-        });
-    return cookie.substr(1)+'='
 }
 
 function clearAuthCookie()
@@ -145,7 +134,7 @@ async function getAuthCookie(cred_username, cred_secure_password)
     console.debug('response received: '+message)
     setcookies = message.headers['set-cookie']
     console.debug('cookies received: '+setcookies)
-    auth_token.api_cookie=parseAuthCookie(setcookies[0])
+    auth_token.api_cookie=setcookies.map(cookie.parse).filter(cookie => cookie['tnm_api'] !== undefined).pop()['tnm_api'];
     auth_token.set_date= new Date()
     console.info('new fresh token retrieved')
     return auth_token.api_cookie

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,11 @@
                 "delayed-stream": "~1.0.0"
             }
         },
+        "cookie": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+            "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        },
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
     "name": "mynewmotion-chargingpoint",
     "version": "0.0.4",
     "dependencies": {
+        "cookie": "^0.4.1",
         "form-data": "^2.5.1",
         "htmlparser2": "^4.0.0",
         "http.min": "^1.3.2"
     },
     "description": "Support for EV charging points.",
     "main": "app.js",
-    "devDependencies": {},
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"
     },


### PR DESCRIPTION
I suddenly ran into an issue with this app over the past week or so. Turns out that the first character of the auth cookie got lost in the process, resulting in 403 responses from NewMotion.

Haven't bumped the version yet or anything, just changed the parsing logic.