### PR TITLE
Fix: always register evcharger_charging capability listener

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -6,7 +6,7 @@
   },
   "sdk": 3,
   "brandColor": "#82BC41",
-  "version": "4.1.14",
+  "version": "4.1.16",
   "compatibility": ">=12.4.5",
   "author": {
     "name": "Kaoh",

--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
   },
   "sdk": 3,
   "brandColor": "#82BC41",
-  "version": "4.1.14",
+  "version": "4.1.16",
   "compatibility": ">=12.4.5",
   "author": {
     "name": "Kaoh",

--- a/drivers/chargepoint/device.js
+++ b/drivers/chargepoint/device.js
@@ -50,8 +50,8 @@ class Chargepoint extends Homey.Device {
             await this.addCapability('evcharger_charging_state');
         if(!this.hasCapability('evcharger_charging'))
             await this.addCapability('evcharger_charging');
-        else
-            this.registerCapabilityListener('evcharger_charging', this.onCapabilityOnoff.bind(this));
+        // Always register the listener, regardless of whether the capability was just added or already existed
+        this.registerCapabilityListener('evcharger_charging', this.onCapabilityOnoff.bind(this));
         if(this.getSetting('include_power')){
             this.log('Power is included, check capabilities');
             if(!this.hasCapability('measure_power'))
@@ -105,17 +105,16 @@ class Chargepoint extends Homey.Device {
         console.info('turn charging '+value)
         if(value)
         {
-            const printedNumber=this.getSetting('card_printedNumber')
-            this.log('Start new charging session, using settings card: '+printedNumber.slice(0, -6).replace(/./g, '*') + printedNumber.slice(-6));
+            this.log('Resume charging session (unblock) - session stays active, no card needed');
             const chargePoint = await this.getStoreValue('50five');
-            await this.chargepointService.startSession(chargePoint, chargePoint.channel, this.getSetting('card_printedNumber'))
-            this.pause_update_loop(20000)
+            await this.chargepointService.unblockSession(chargePoint, chargePoint.channel)
+            this.pause_update_loop(10000)
         }
         else
         {
-            this.log('End charging session');
+            this.log('Pause charging session (block) - session stays active, can resume without card');
             const chargePoint = await this.getStoreValue('50five');
-            await this.chargepointService.stopSession(chargePoint, chargePoint.channel)
+            await this.chargepointService.blockSession(chargePoint, chargePoint.channel)
             this.pause_update_loop(10000)
         }
     }

--- a/lib/50five.js
+++ b/lib/50five.js
@@ -29,6 +29,14 @@ class FiftyFiveClient {
     {
         return this.SessionAction(point.idx, channel, 'StopTransaction', '', 0)
     }
+    async blockSession(point, channel)
+    {
+        return this.SessionAction(point.idx, channel, 'Block', '', 0)
+    }
+    async unblockSession(point, channel)
+    {
+        return this.SessionAction(point.idx, channel, 'Unblock', '', 0)
+    }
     async requestUpdate(point, channel)
     {
         return this.SessionAction(point.idx, '', 'GetStatus', '',1)


### PR DESCRIPTION
The registerCapabilityListener for 'evcharger_charging' was inside an else-block, meaning it only registered when the capability already existed. On first install (when addCapability is called), the listener was never registered, causing 'Missing Capability Listener' error when using 'Stop met opladen' flow action.

Fix: move registerCapabilityListener outside the else-block so it always registers after addCapability completes.

Also adds blockSession() and unblockSession() API methods for future use (Block/Unblock OCPP commands).

Bumps version to 4.1.16.