### PR TITLE
Fix: use start/stop session when no active session exists

### DIFF
--- a/drivers/chargepoint/device.js
+++ b/drivers/chargepoint/device.js
@@ -100,23 +100,32 @@ class Chargepoint extends Homey.Device {
 
 
     // this method is called when the Device has requested a state change (turned on or off)
-	async onCapabilityOnoff( value, opts ) {
-        this.setIfHasCapability('evcharger_charging', value)
-        console.info('turn charging '+value)
-        if(value)
-        {
-            this.log('Resume charging session (unblock) - session stays active, no card needed');
-            const chargePoint = await this.getStoreValue('50five');
-            await this.chargepointService.unblockSession(chargePoint, chargePoint.channel)
-            this.pause_update_loop(10000)
+    async onCapabilityOnoff( value, opts ) {
+        this.setIfHasCapability('evcharger_charging', value);
+        console.info('turn charging ' + value);
+        const chargePoint = await this.getStoreValue('50five');
+        const state = this.getCapabilityValue('evcharger_charging_state');
+        const hasActiveSession = state === 'plugged_in_charging' || state === 'plugged_in_paused';
+
+        if (value) {
+            if (hasActiveSession) {
+                this.log('Resume charging session (unblock) - active session found, no card needed');
+                await this.chargepointService.unblockSession(chargePoint, chargePoint.channel);
+            } else {
+                this.log('Start new charging session - no active session, using card');
+                const rfid = chargePoint.card?.printedNumber || this.getSetting('card_printedNumber') || '';
+                await this.chargepointService.startSession(chargePoint, chargePoint.channel, rfid);
+            }
+        } else {
+            if (hasActiveSession) {
+                this.log('Pause charging session (block) - session stays active, can resume without card');
+                await this.chargepointService.blockSession(chargePoint, chargePoint.channel);
+            } else {
+                this.log('Stop charging session - no active session to block');
+                await this.chargepointService.stopSession(chargePoint, chargePoint.channel);
+            }
         }
-        else
-        {
-            this.log('Pause charging session (block) - session stays active, can resume without card');
-            const chargePoint = await this.getStoreValue('50five');
-            await this.chargepointService.blockSession(chargePoint, chargePoint.channel)
-            this.pause_update_loop(10000)
-        }
+        this.pause_update_loop(10000);
     }
     
     delay(t, val) {


### PR DESCRIPTION
onCapabilityOnoff previously always used block/unblock, causing charging to start and immediately stop when no active session was present.

Now checks evcharger_charging_state first:
- plugged_in_charging / plugged_in_paused -> block/unblock (existing session)
- no active session -> startSession / stopSession with card

## Probleem
De vorige fix (always register capability listener) werkte correct, maar 
onCapabilityOnoff gebruikte altijd block/unblock — ook zonder actieve sessie. 
Dit veroorzaakte het gemelde gedrag: laden start en stopt direct.

## Oorzaak
unblockSession() vereist een bestaande actieve sessie. Zonder actieve sessie 
mislukt de aanroep, waarna Homey de status terugdraait naar false → laadpaal 
stopt direct.

## Oplossing
onCapabilityOnoff controleert nu eerst de evcharger_charging_state:
- plugged_in_charging / plugged_in_paused → block/unblock (sessie actief)
- Geen actieve sessie → startSession/stopSession met RFID kaart

## Gedrag na fix
- Aanzetten zonder actieve sessie → start nieuwe sessie met kaart ✓
- Aanzetten met gepauzeerde sessie → hervatten via unblock ✓
- Uitzetten met actieve sessie → pauzeren via block ✓
- Uitzetten zonder actieve sessie → stopSession ✓