### PR TITLE
Fix: add pause_on_stop setting, default to stopSession (restores v4.1…

### DIFF
--- a/drivers/chargepoint/device.js
+++ b/drivers/chargepoint/device.js
@@ -118,10 +118,16 @@ class Chargepoint extends Homey.Device {
             }
         } else {
             if (hasActiveSession) {
-                this.log('Pause charging session (block) - session stays active, can resume without card');
-                await this.chargepointService.blockSession(chargePoint, chargePoint.channel);
+                const pauseOnStop = this.getSetting('pause_on_stop') ?? false;
+                if (pauseOnStop) {
+                    this.log('Pause charging session (block) - pause_on_stop enabled, session stays active, can resume without card');
+                    await this.chargepointService.blockSession(chargePoint, chargePoint.channel);
+                } else {
+                    this.log('Stop charging session - pause_on_stop disabled (default), ending session completely');
+                    await this.chargepointService.stopSession(chargePoint, chargePoint.channel);
+                }
             } else {
-                this.log('Stop charging session - no active session to block');
+                this.log('Stop charging session - no active session');
                 await this.chargepointService.stopSession(chargePoint, chargePoint.channel);
             }
         }

--- a/drivers/chargepoint/driver.compose.json
+++ b/drivers/chargepoint/driver.compose.json
@@ -86,6 +86,19 @@
         "nl": "Laad vermogen in Energie weergeven"
       },
       "value": true
+    },
+    {
+      "id": "pause_on_stop",
+      "type": "checkbox",
+      "label": {
+        "en": "Pause session on stop (instead of stopping it)",
+        "nl": "Sessie pauzeren bij stoppen (in plaats van beëindigen)"
+      },
+      "hint": {
+        "en": "ON: blocks the session so it can be resumed without RFID card (useful for automatic energy management). OFF: stops the session completely, RFID card required to start again (default, same as v4.1.14).",
+        "nl": "AAN: pauzeert de sessie zodat deze hervat kan worden zonder laadpas (handig voor automatisch energiebeheer). UIT: beëindigt de sessie volledig, laadpas nodig om opnieuw te starten (standaard, zelfde als v4.1.14)."
+      },
+      "value": false
     }
   ]
 }


### PR DESCRIPTION
….14 behaviour)

- Default (false): stopSession() when stopping an active session - same as v4.1.14
- pause_on_stop=true: blockSession() to preserve session for resumption without RFID (useful for automatic energy management like Frank Energy imbalance charging)

This fixes the regression reported by users where blockSession() was causing the charger to show a red light and become fully blocked.