### PR TITLE
Fix: 7 bug fixes for button revert, silent API failures, and stability

### DIFF
--- a/drivers/chargepoint/device.js
+++ b/drivers/chargepoint/device.js
@@ -131,9 +131,9 @@ class Chargepoint extends Homey.Device {
                 await this.chargepointService.stopSession(chargePoint, chargePoint.channel);
             }
         }
-        this.pause_update_loop(10000);
+        this.pause_update_loop(30000);
     }
-    
+
     delay(t, val) {
         return new Promise(function(resolve) {
             setTimeout(function() {
@@ -144,11 +144,13 @@ class Chargepoint extends Homey.Device {
 
     onAdded() {
         //Lets persist the printedNumber of the selected card during setup into a setting
-        const point =this.getData();
-        this.setSettings({
-            card_printedNumber:point.card.printedNumber
-        });
-        Console.log('Stored selected card into device settings')
+        const point = this.getData();
+        if (point.card?.printedNumber) {
+            this.setSettings({
+                card_printedNumber: point.card.printedNumber
+            });
+        }
+        console.log('Stored selected card into device settings')
     }
 
     onDeleted() {
@@ -692,7 +694,7 @@ class Chargepoint extends Homey.Device {
         this.setIfHasCapability('onoff',data.e.activeSession)
         this.setIfHasCapability('occupied', (data.e.free == 0))
         this.setIfHasCapability('charging', (data.e.charging > 0))
-        this.setIfHasCapability('evcharger_charging', data.e.activeSession)
+        this.setIfHasCapability('evcharger_charging', data.e.charging > 0)
         this.setIfHasCapability('connectors.total', data.e.total)
         this.setIfHasCapability('connectors.free', data.e.free)
         if(data.e.availablepower>0)
@@ -921,12 +923,21 @@ class Chargepoint extends Homey.Device {
             console.log('attempt to stop the active charge session');
             return new Promise((resolve, reject) => {
                 const chargePoint = this.getStoreValue('50five');
-                this.chargepointService.stopSession(chargePoint, chargePoint.channel).then(() => {
+                const state = this.getCapabilityValue('evcharger_charging_state');
+                const hasActiveSession = state === 'plugged_in_charging' || state === 'plugged_in_paused';
+                const pauseOnStop = this.getSetting('pause_on_stop') ?? false;
+                let action;
+                if (hasActiveSession && pauseOnStop) {
+                    action = this.chargepointService.blockSession(chargePoint, chargePoint.channel);
+                } else {
+                    action = this.chargepointService.stopSession(chargePoint, chargePoint.channel);
+                }
+                action.then(() => {
                     resolve(true);
                 }, (_error) => {
                   resolve(false);
                 });
-                this.pause_update_loop(10000)
+                this.pause_update_loop(30000);
             });
           });
       }

--- a/lib/50five.js
+++ b/lib/50five.js
@@ -86,7 +86,7 @@ class FiftyFiveClient {
         })
         .catch(err => {
             console.error('❌ 4.1: command rejected:', err.message);
-            return err;
+            throw err;
         })
     };
 
@@ -279,7 +279,7 @@ class FiftyFiveClient {
         } catch (err) {
             this.clearAuthCookie();
             console.info('could not decrypt using salt, network connection changed?');
-            return;   
+            return '';
         }
         console.log('credentials retrieved from settings and decrypted')
 


### PR DESCRIPTION
## Summary

Follow-up to #31. These fixes address the root cause of the "button briefly turns off then back on" issue reported by KingSize32, plus several other bugs found during investigation.

## Changes

### device.js

**Fix #1 - Button reverts after stop (root cause of KingSize32's issue)**

`evcharger_charging` was set to `activeSession` in the update loop. When a car is plugged in (even after a successful stop/block), `activeSession` stays `true`, so the button snapped back to ON every 2 minutes. Changed to `charging > 0` - only true when current is actually flowing.

**Fix #2 - `pause_update_loop` 10s ? 30s**

10 seconds was too short for the charger to process `StopTransaction`. The loop fired before the command completed, saw the charger still charging, and reverted. 30 seconds gives the hardware time to respond.

**Fix #3 - `Console.log` ReferenceError in `onAdded()`**

Capital-C `Console.log` threw a ReferenceError when adding a new device.

**Fix #4 - Null guard in `onAdded()`**

`point.card.printedNumber` crashed if no card was selected during pairing. Changed to `point.card?.printedNumber` with a guard.

**Fix #5 - `stop_charge_generic` flow card ignored `pause_on_stop` setting**

The flow card action always called `stopSession()` directly, bypassing the `pause_on_stop` setting added in #31. Flow card now respects the setting consistently with the toggle button.

### lib/50five.js

**Fix #6 - `SessionAction` swallows API errors (`return err` ? `throw err`)**

The `.catch` block was returning the error object instead of throwing it. This meant all API command failures (stop, start, block, unblock) were silently treated as successes - the capability state would not revert and no error was logged. Now errors propagate properly.

**Fix #7 - `getAuthCookie()` returns `undefined` on decrypt failure**

`return;` after a failed decrypt returned `undefined` instead of `''`. The caller's `if (fresh_token == '')` check uses `==` which does not catch `undefined`, so the device proceeded with a stale/empty token. Changed to `return '';`.

## Relation to KingSize32's bug

With fixes #1 and #2 together:
- Fix #1 prevents the update loop from resetting the button to ON when the car is plugged in but not actively charging
- Fix #2 gives the charger enough time to actually stop before the loop re-reads state
- Fix #6 ensures that if the API command itself fails, the error is visible in logs