### PR TITLE
Fix: catch unhandled rejections in update loop (v4.1.21)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1,4 +1,7 @@
 {
+  "4.1.21": {
+    "en": "Fix: update loop and pause_update_loop now catch unhandled rejections from updateDevice() to prevent app crashes on detached async callbacks. Contributed by Coert Noordermeer."
+  },
   "2.1.0": {
     "en": "Added more detailed flow events and base support for homey 3.0 power management. "
   },

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -6,7 +6,7 @@
   },
   "sdk": 3,
   "brandColor": "#82BC41",
-  "version": "4.1.20",
+  "version": "4.1.21",
   "compatibility": ">=12.4.5",
   "author": {
     "name": "Kaoh",

--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
   },
   "sdk": 3,
   "brandColor": "#82BC41",
-  "version": "4.1.20",
+  "version": "4.1.21",
   "compatibility": ">=12.4.5",
   "author": {
     "name": "Kaoh",

--- a/drivers/chargepoint/device.js
+++ b/drivers/chargepoint/device.js
@@ -162,11 +162,10 @@ class Chargepoint extends Homey.Device {
 
     start_update_loop() {
         this._timer = setInterval(() => {
-            this.updateDevice();
+            this.updateDevice().catch(err => this.error('update loop:', err));
         }, 120000); //2 minute
     }
 
-    
     pause_update_loop(delay) {
         //Clear the timer to ensure we dont hit one to soon
         if (this._timer) {
@@ -175,8 +174,8 @@ class Chargepoint extends Homey.Device {
             this._timer = null;
         }
         setTimeout(() => {
-            this.updateDevice()
-            this.start_update_loop()
+            this.updateDevice().catch(err => this.error('pause_update_loop:', err));
+            this.start_update_loop();
         }, delay); // custom delay
     }
 


### PR DESCRIPTION
## Summary

Addresses the error-handling note in CONTRIBUTING.md.

`updateDevice()` was called from `setInterval` and `setTimeout` callbacks in `start_update_loop` and `pause_update_loop` without any error handling. The Homey SDK treats unhandled promise rejections from detached async callbacks as fatal - the app crashes. Added `.catch(err => this.error(...))` to both.

## Changes

**device.js**

`js
// Before
this._timer = setInterval(() => {
    this.updateDevice();
}, 120000);

// After
this._timer = setInterval(() => {
    this.updateDevice().catch(err => this.error('update loop:', err));
}, 120000);
`

Same pattern applied to the `setTimeout` inside `pause_update_loop`.

## Release prep (per CONTRIBUTING.md)

- Version bumped to **4.1.21** in `.homeycompose/app.json` and `app.json`
- Changelog entry added to `.homeychangelog.json`
- Note: `homey app validate --level publish` could not be run locally (no CLI); happy to adjust if validation reveals anything

## Response to your feedback

Thanks for setting up CONTRIBUTING.md - included version bump and changelog in this PR as requested. You should be able to `git pull && homey app publish` straight after merge.